### PR TITLE
[FIX] build.gradle compile code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,16 +4,16 @@ repositories {
 }
 
 dependencies {
-    compile 'org.slf4j:slf4j-api:1.7.21'
-    testCompile 'junit:junit:4.12'
-    compile 'io.reactivex.rxjava2:rxjava:2.2.7'
-    compile 'com.squareup.retrofit2:retrofit:2.0.2'
-	compile 'com.squareup.retrofit2:converter-gson:2.0.2'
-	compile 'com.squareup.okhttp3:okhttp:3.2.0'
-	compile 'org.apache.commons:commons-lang3:3.1'
-	compile "com.github.akarnokd:rxjava2-extensions:0.17.5"
+    implementation 'org.slf4j:slf4j-api:1.7.21'
+    testImplementation 'junit:junit:4.12'
+    implementation 'io.reactivex.rxjava2:rxjava:2.2.7'
+    implementation 'com.squareup.retrofit2:retrofit:2.0.2'
+	implementation 'com.squareup.retrofit2:converter-gson:2.0.2'
+	implementation 'com.squareup.okhttp3:okhttp:3.2.0'
+	implementation 'org.apache.commons:commons-lang3:3.1'
+	testImplementation "com.github.akarnokd:rxjava2-extensions:0.17.5"
 	
-	testCompile 'org.junit.jupiter:junit-jupiter-api:5.0.0-RC2'
-	testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.0.0-RC2'
-	testCompile 'org.junit.platform:junit-platform-runner:1.0.0-RC2'
+	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.0.0-RC2'
+	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.0.0-RC2'
+	testImplementation 'org.junit.platform:junit-platform-runner:1.0.0-RC2'
 }


### PR DESCRIPTION
## Summary
- Could not find method compile() for arguments 에러가 발생하여 수정했습니다. 

## Detailed
- compile, runtime, testCompile, testRuntime이 deprecated 되어 에러가 발생합니다. 
- 이후 버전에서는 implementation, runtimeOnly, testImplementation, testRuntimeOnly 으로 변경되었습니다. 
- 참고자료: https://velog.io/@g0709-19/Gradle-Could-not-find-method-compile-해결-방법 